### PR TITLE
Allow TF 0.14 and up in new_state configuration

### DIFF
--- a/new_state/main.tf
+++ b/new_state/main.tf
@@ -5,7 +5,7 @@ terraform {
       version = ">= 3.24.1"
     }
   }
-  required_version = "~> 0.14"
+  required_version = ">= 0.14"
 }
 
 variable "region" {


### PR DESCRIPTION
This allows usage of current TF versions with the tutorial at https://learn.hashicorp.com/tutorials/terraform/state-cli.